### PR TITLE
Develop

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  git: 'https://github.com/ricaragao/meteor-collection-softremovable.git',
+  git: 'https://github.com/sbborders/meteor-collection-softremovable.git',
   name: 'sbborders:collection-softremovable',
   summary: 'Add soft remove to collections',
   version: '2.0.1',

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   git: 'https://github.com/ricaragao/meteor-collection-softremovable.git',
   name: 'sbborders:collection-softremovable',
   summary: 'Add soft remove to collections',
-  version: '2.0.0',
+  version: '2.0.1',
   documentation: 'README.md',
 });
 

--- a/softremovable.js
+++ b/softremovable.js
@@ -172,10 +172,18 @@ const behaviour = function (options) {
 
     try {
       if (Meteor.isServer || isLocalCollection) {
-        ret = await this.updateAsync(selector, modifier, { multi: true }, callback);
+        if (this.direct) {
+          ret = await this.direct.updateAsync(selector, modifier, { multi: true }, callback);
+        } else {
+          ret = await this.updateAsync(selector, modifier, { multi: true }, callback);
+        }
 
       } else {
-        ret = await this.updateAsync(selector, modifier, callback);
+        if (this.direct) {
+          ret = await this.direct.updateAsync(selector, modifier, callback);
+        } else {
+          ret = await this.updateAsync(selector, modifier, callback);
+        }
       }
 
     } catch (error) {
@@ -206,13 +214,22 @@ const behaviour = function (options) {
       if (Meteor.isServer || isLocalCollection) {
         selector = _.clone(selector);
         selector["removed"] = true;
-        ret = await this.updateAsync(selector, modifier, { multi: true }, callback);
+        if (this.direct) {
+          ret = await this.direct.updateAsync(selector, modifier, { multi: true }, callback);
+        } else {
+          ret = await this.updateAsync(selector, modifier, { multi: true }, callback);
+        }
 
       } else {
-        ret = await this.updateAsync(selector, modifier, callback);
+        if (this.direct) {
+          ret = await this.direct.updateAsync(selector, modifier, callback);
+        } else {
+          ret = await this.updateAsync(selector, modifier, callback);
+        }
       }
 
     } catch (error) {
+      console.log(error);
       if (error.reason.indexOf('Not permitted.' !== -1)) {
         throw new Meteor.Error(403, 'Not permitted. Untrusted code may only ' +
           "restore documents by ID."


### PR DESCRIPTION
When a collection is being defined with matb33:collection-hooks , can have a bug if there is any dependency in the definitions. Then, it was applied a change to use the form `direct` that collection-hooks provide to avoid this issue.